### PR TITLE
Correct CouchDbSessionTokenTest declared exceptions

### DIFF
--- a/modules/common/src/test/java/com/ibm/cloud/cloudant/security/CouchDbSessionTokenTest.java
+++ b/modules/common/src/test/java/com/ibm/cloud/cloudant/security/CouchDbSessionTokenTest.java
@@ -14,13 +14,14 @@
 package com.ibm.cloud.cloudant.security;
 
 
-import com.ibm.cloud.cloudant.security.CouchDbSessionAuthenticator.CouchDbSessionToken;
-import org.testng.annotations.Test;
-
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
+
+import com.ibm.cloud.cloudant.security.CouchDbSessionAuthenticator.CouchDbSessionToken;
+
+import org.testng.annotations.Test;
 
 
 public class CouchDbSessionTokenTest {
@@ -36,9 +37,11 @@ public class CouchDbSessionTokenTest {
 
     /**
      * Test that a token needs refresh after 80% of it's lifetime
+     *
+     * @throws InterruptedException if the test is interrupted while sleeping
      */
     @Test
-    public void needsRefresh() throws Exception {
+    public void needsRefresh() throws InterruptedException {
         // 1 second lifetime
         CouchDbSessionToken t = new CouchDbSessionToken(System.currentTimeMillis() + 1000);
         // The minimum refresh time is 800 ms, sleep for slightly longer than that (850 ms) to allow
@@ -62,7 +65,7 @@ public class CouchDbSessionTokenTest {
      * Test that a token refresh calculation is correct
      */
     @Test
-    public void refreshTimeCalculation() throws Exception {
+    public void refreshTimeCalculation() {
         long currentTime = System.currentTimeMillis();
         CouchDbSessionToken t = new CouchDbSessionToken(currentTime + 1000);
         assertEquals(200, t.expiryTime - t.refreshTime, "The time between refresh and expiry should be 200 ms");


### PR DESCRIPTION
## PR summary

Correct exceptions thrown by test code, see:
https://github.com/IBM/cloudant-java-sdk/pull/52#discussion_r539243404
https://github.com/IBM/cloudant-java-sdk/pull/52#discussion_r539246413

## PR Checklist

Please make sure that your PR fulfills the following requirements:

- [x The commit message follows the
[Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type  
<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [ ] Build/CI related changes
- [ ] Documentation content changes
- [x] Other (please describe) - test fix

## What is the current behavior?

`needsRefresh()` test declares `Exception` which is more broad than the `InterruptedException` needed.
`refreshTimeCalculation()` test declares that it throws `Exception` unnecessarily.

## What is the new behavior?
<!-- Please describe the new behavior after your change. -->

`needsRefresh()` - `throws InterruptedException`.
`refreshTimeCalculation()` - removed `throws` declaration.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and
migration path for existing applications below. -->

## Other information

<!-- Please add any additional information that would help reviewers evaluate
your PR-->
@vmatyusGitHub I felt it was worth still correcting these test issues that were uncovered as part of #52