### PR TITLE
Publish javadoc to GH pages

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,6 +11,8 @@ Jenkinsfile @IBM/cloudant-sdks
 KNOWN_ISSUES.md @IBM/cloudant-sdks
 LICENSE @IBM/cloudant-sdks
 README.md @IBM/cloudant-sdks
+scripts/javadoc/generate-index-html.sh @IBM/cloudant-sdks
+scripts/javadoc/publish-doc.sh @IBM/cloudant-sdks
 scripts/setup_couch.sh @IBM/cloudant-sdks
 scripts/setup_wiremock.sh @IBM/cloudant-sdks
 stubs/mappings.json @IBM/cloudant-sdks

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -18,12 +18,12 @@ pipeline {
           applyCustomizations()
           checkoutResult = checkout scm
           commitHash = "${checkoutResult.GIT_COMMIT[0..6]}"
-          sh """
-            git config user.email '71659186+cloudant-sdks-automation@users.noreply.github.com'
-            git config user.name 'cloudant-sdks-automation'
-            git config credential.username '${env.GH_CREDS_USR}'
-            git config credential.helper '!f() { echo password=\$GH_CREDS_PSW; echo; }; f'
-          """
+          sh '''
+            git config --global user.email $GH_SDKS_AUTOMATION_MAIL
+            git config --global user.name $GH_CREDS_USR
+            git config --global credential.username $GH_CREDS_USR
+            git config --global credential.helper '!f() { echo password=\$GH_CREDS_PSW; echo; }; f'
+          '''
         }
       }
     }
@@ -108,6 +108,7 @@ pipeline {
         // Push the version bump and release tag
         sh 'git push --tags origin HEAD:master'
         publishPublic()
+        publishDocs()
       }
     }
   }
@@ -162,6 +163,7 @@ String getNewVersion(isDevRelease, version) {
 // runTests()
 // publishStaging()
 // publishPublic()
+// publishDocs()
 // + other customizations
 void applyCustomizations() {
   libName = 'java'
@@ -195,5 +197,9 @@ void publishPublic() {
 
 void publishMaven(mvnArgs='') {
   sh "mvn deploy --settings build/.travis.settings.xml -DskipTests ${mvnArgs}"
+}
+
+void publishDocs() {
+  sh './scripts/javadoc/publish-doc.sh'
 }
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 
 [![Build Status](https://travis-ci.com/IBM/cloudant-java-sdk.svg?branch=master)](https://travis-ci.com/IBM/cloudant-java-sdk)
 [![Release](https://img.shields.io/github/v/release/IBM/cloudant-java-sdk?include_prereleases&sort=semver)](https://github.com/IBM/cloudant-java-sdk/releases/latest)
+[![Docs](https://img.shields.io/static/v1?label=javadoc&message=latest&color=blue)](https://ibm.github.io/cloudant-java-sdk/)
 
 # IBM Cloudant Java SDK Version 0.0.20
 

--- a/scripts/javadoc/generate-index-html.sh
+++ b/scripts/javadoc/generate-index-html.sh
@@ -1,0 +1,30 @@
+#!/bin/sh -e
+
+# based on https://odoepner.wordpress.com/2012/02/17/shell-script-to-generate-simple-index-html/
+
+echo '<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>IBM Cloudant SDK for Java</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+</head>
+<body>
+<div class="container">
+    <div class="page-header">
+        <h1>IBM Cloudant Java SDK Documentation</h1>
+    </div>
+
+    <p><a href="https://cloud.ibm.com/apidocs/cloudant?code=java">Cloudant API Docs</a>
+        | <a href="https://github.com/IBM/cloudant-java-sdk">GitHub</a>
+    </p>
+
+    <p>Javadoc by release:</p>
+    <ul><li><a href="docs/latest">Latest</a></li>'
+ls docs | grep --invert-match index.html | grep -v latest | sed 's/^.*/<li><a href="docs\/&">&<\/a><\/li>/'
+echo '    </ul>
+</div>
+</body>
+</html>'

--- a/scripts/javadoc/publish-doc.sh
+++ b/scripts/javadoc/publish-doc.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+
+set -e
+
+# Store GIT properties in vars
+GIT_COMMIT=$(git rev-parse --short HEAD)
+GIT_REPO=$(git remote get-url origin)
+
+# Create documentation
+printf ">>>>> Generate new documentation\n"
+mvn javadoc:aggregate
+
+# Clone gh-pages branch
+printf ">>>>> Publishing javadoc for release build: repo=%s branch=%s build_num=%s job_name=%s\n" ${GIT_REPO} ${BRANCH_NAME} ${BUILD_NUMBER} ${JOB_NAME}
+printf ">>>>> Cloning repository's gh-pages branch into directory 'gh-pages'\n"
+git clone --branch=gh-pages https://github.com/IBM/cloudant-java-sdk.git gh-pages
+
+printf ">>>>> Finished cloning...\n"
+
+pushd gh-pages
+
+# Create a new directory for this tag_name and copy the aggregated javadocs there, if it's a tagged release.
+if [ -n "TAG_NAME" ]; then
+  printf "\n>>>>> Copying aggregated javadocs to new tagged-release directory: %s\n" ${BRANCH_NAME}
+  rm -rf docs/${TAG_NAME}
+  mkdir -p docs/${TAG_NAME}
+  cp -rf ../target/site/apidocs/* docs/${TAG_NAME}
+
+  printf "\n>>>>> Generating gh-pages index.html...\n"
+  ../scripts/javadoc/generate-index-html.sh > index.html
+
+  # Update the 'latest' symlink to point to this directory
+  pushd docs
+  rm -f latest
+  ln -s ./${TAG_NAME} latest
+  printf "\n>>>>> Updated 'docs/latest' symlink:\n"
+  ls -l latest
+  popd
+
+  printf "\n>>>>> Committing new javadoc...\n"
+  git add -f .
+  git commit -m "Javadoc for release ${TAG_NAME} (${GIT_COMMIT})"
+  git push -f origin gh-pages
+
+  popd
+
+  printf "\n>>>>> Published javadoc for release build: repo=%s branch=%s build_num=%s job_name=%s\n" ${GIT_REPO} ${BRANCH_NAME} ${BUILD_NUMBER} ${JOB_NAME}
+else
+  printf "\n>>>>> Failed to publish javadoc for release build: TAG_NAME was empty\n"
+fi


### PR DESCRIPTION
## PR summary

Relates to: sdks/doc-generation

## PR Checklist

Please make sure that your PR fulfills the following requirements:

- [ ] The commit message follows the
[Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type  
<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [ ] Build/CI related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->
There were no javadoc publishment.

## What is the new behavior?
<!-- Please describe the new behavior after your change. -->
This enhancement publish the generated javadoc to GH pages.
A new `gh-pages` branch was created, from where the GitHub Pages being built.
Can be configured from `Settings -> GitHub Pages`

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and
migration path for existing applications below. -->

## Other information

<!-- Please add any additional information that would help reviewers evaluate
your PR-->

This PR will be not merged, I made this to make my changes more transparent.
Here you can review the full documentation deployment process.
These changes will be generated by sdks.

Currently the document publish runs in stage, so each time the stage is executed with tag test-doc.
In the end, the document will be created only when new release published with the release tag, this change will be made later.
