### PR TITLE
Change maven-checkstyle-plugin to use checkstyle version 9.0.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -303,6 +303,13 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-checkstyle-plugin</artifactId>
                     <version>${maven-checkstyle-plugin-version}</version>
+                    <dependencies>
+                        <dependency>
+                            <groupId>com.puppycrawl.tools</groupId>
+                            <artifactId>checkstyle</artifactId>
+                            <version>9.0.1</version>
+                        </dependency>
+                    </dependencies>
                     <executions>
                         <execution>
                             <id>verify-style</id>


### PR DESCRIPTION
## PR summary

<!-- please include a brief summary of the changes in this PR -->

This PR adds configuration for `maven-checkstyle-plugin` to use `checkstyle` version 9.0.1 (latest atm) instead of default 8.29

Fixes: #177 

**Note: An existing issue is [required](https://github.com/IBM/cloudant-java-sdk/blob/master/CONTRIBUTING.md#PRs) before opening a PR.**

## PR Checklist

Please make sure that your PR fulfills the following requirements:

- [x] The commit message follows the
[Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type  
<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [x] Build/CI related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

Old `checkstyle` used leading to upgrade warnings during the tests.

## What is the new behavior?
<!-- Please describe the new behavior after your change. -->

New `checkstyle` used with warnings gone

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and
migration path for existing applications below. -->

## Other information

<!-- Please add any additional information that would help reviewers evaluate
your PR-->
