### PR TITLE
Support alias env var AUTHTYPE

### DIFF
--- a/modules/common/src/main/java/com/ibm/cloud/cloudant/internal/DelegatingAuthenticatorFactory.java
+++ b/modules/common/src/main/java/com/ibm/cloud/cloudant/internal/DelegatingAuthenticatorFactory.java
@@ -20,6 +20,8 @@ import com.ibm.cloud.cloudant.security.CouchDbSessionAuthenticator;
 
 import java.util.Map;
 
+import org.apache.commons.lang3.StringUtils;
+
 /**
  * This class serves as an Authenticator factory.
  * It will detect and use various configuration sources in order to produce an Authenticator
@@ -38,12 +40,20 @@ public class DelegatingAuthenticatorFactory extends ConfigBasedAuthenticatorFact
 
     static Authenticator getAuthenticator(String serviceName,
                                                  Map<String, String> serviceProperties) {
-        // If the auth type is COUCHDB_SESSION create the authenticator
-        if (serviceProperties != null && !serviceProperties.isEmpty()
-                && CouchDbSessionAuthenticator.AUTH_TYPE.equalsIgnoreCase(serviceProperties.get(Authenticator.PROPNAME_AUTH_TYPE))) {
-            return CouchDbSessionAuthenticator.newAuthenticator(
-                    serviceProperties.get(Authenticator.PROPNAME_USERNAME),
-                    serviceProperties.get(Authenticator.PROPNAME_PASSWORD));
+        if (serviceProperties != null && !serviceProperties.isEmpty()) {
+            String authType = serviceProperties.get(Authenticator.PROPNAME_AUTH_TYPE);
+
+            if (StringUtils.isEmpty(authType)) {
+                // this property doesn't have an according Authenticator constant
+                authType = serviceProperties.get("AUTHTYPE");
+            }
+
+            // If the auth type is COUCHDB_SESSION create the authenticator
+            if (CouchDbSessionAuthenticator.AUTH_TYPE.equalsIgnoreCase(authType)) {
+                return CouchDbSessionAuthenticator.newAuthenticator(
+                        serviceProperties.get(Authenticator.PROPNAME_USERNAME),
+                        serviceProperties.get(Authenticator.PROPNAME_PASSWORD));
+            }
         }
 
         // For all other auth types, delegate to the core factory

--- a/modules/common/src/test/java/com/ibm/cloud/cloudant/internal/DelegatingAuthenticatorFactoryTest.java
+++ b/modules/common/src/test/java/com/ibm/cloud/cloudant/internal/DelegatingAuthenticatorFactoryTest.java
@@ -41,17 +41,25 @@ class DelegatingAuthenticatorFactoryTest {
         servicePropsBase.put(Authenticator.PROPNAME_PASSWORD, "testpass");
     }
 
-    private Map<String, String> getServicePropsWithAuthType(String authType) {
+    private Map<String, String> getServicePropsWithAuthType(String propName, String authType) {
         Map<String, String> serviceProps = new HashMap<>();
         serviceProps.putAll(servicePropsBase);
-        serviceProps.put(Authenticator.PROPNAME_AUTH_TYPE, authType);
+        serviceProps.put(propName, authType);
         return serviceProps;
     }
 
     @Test
     void getAuthenticatorForSessionAuthType() {
         Authenticator authenticator = DelegatingAuthenticatorFactory.getAuthenticator("test",
-                getServicePropsWithAuthType("COUCHDB_SESSION"));
+                getServicePropsWithAuthType(Authenticator.PROPNAME_AUTH_TYPE, "COUCHDB_SESSION"));
+        assertTrue(authenticator instanceof CouchDbSessionAuthenticator, "Should return an " +
+                "instance of CouchDbSessionAuthenticator");
+    }
+
+    @Test
+    void getAuthenticatorForSessionAuthTypeAlias() {
+        Authenticator authenticator = DelegatingAuthenticatorFactory.getAuthenticator("test",
+                getServicePropsWithAuthType("AUTHTYPE", "COUCHDB_SESSION"));
         assertTrue(authenticator instanceof CouchDbSessionAuthenticator, "Should return an " +
                 "instance of CouchDbSessionAuthenticator");
     }
@@ -59,7 +67,7 @@ class DelegatingAuthenticatorFactoryTest {
     @Test
     void getAuthenticatorForOtherAuthType() {
         Authenticator authenticator = DelegatingAuthenticatorFactory.getAuthenticator("test",
-                getServicePropsWithAuthType("BASIC"));
+                getServicePropsWithAuthType(Authenticator.PROPNAME_AUTH_TYPE, "BASIC"));
         assertFalse(authenticator instanceof CouchDbSessionAuthenticator, "Should not return " +
                 "an instance of CouchDbSessionAuthenticator");
     }


### PR DESCRIPTION
## PR summary

Support a env var name alias `AUTHTYPE` for `AUTH_TYPE` to keep core's compatibility

## PR Checklist

Please make sure that your PR fulfills the following requirements:

- [x] The commit message follows the
[Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type  
<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [ ] Build/CI related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->
Env var of format `SERVICE_AUTHTYPE` is ignored and error thrown on missing required variable

## What is the new behavior?
<!-- Please describe the new behavior after your change. -->
Env var of format `SERVICE_AUTHTYPE` accepted as a valid variable same as `SERVICE_AUTH_TYPE`

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and
migration path for existing applications below. -->

## Other information

<!-- Please add any additional information that would help reviewers evaluate
your PR-->
