### PR TITLE
Validate trailing slash stripped on setting of service URL

### DIFF
--- a/modules/common/src/test/java/com/ibm/cloud/cloudant/internal/ValidationTest.java
+++ b/modules/common/src/test/java/com/ibm/cloud/cloudant/internal/ValidationTest.java
@@ -1,5 +1,5 @@
 /**
- * © Copyright IBM Corporation 2021. All Rights Reserved.
+ * © Copyright IBM Corporation 2021, 2022 All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -11,6 +11,8 @@
  * specific language governing permissions and limitations under the License.
  */
 package com.ibm.cloud.cloudant.internal;
+
+import static org.testng.Assert.assertEquals;
 
 import java.util.Map;
 import java.util.Map.Entry;
@@ -69,5 +71,13 @@ public class ValidationTest {
           rb.header(header.getKey(), header.getValue());
         }
         cloudantBaseService.createServiceCall(rb.build(), null);
+    }
+
+    @Test
+    void validatesStripTrailingSlash() {
+        CloudantBaseService cloudantBaseService = new CloudantBaseService(null, new NoAuthAuthenticator()) {
+        };
+        cloudantBaseService.setServiceUrl("https://cloudant.example/");
+        assertEquals(cloudantBaseService.getServiceUrl(), "https://cloudant.example");
     }
 }


### PR DESCRIPTION
## PR summary

Add a test to validate that we are stripping a trailing slash on setting of service URL. The test for env file is not necessary, since it's using the same `setServiceUrl` function under the hood.

## PR Checklist

Please make sure that your PR fulfills the following requirements:

- [x] The commit message follows the
[Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type  
<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] New tests
- [ ] Build/CI related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

## What is the new behavior?
<!-- Please describe the new behavior after your change. -->

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and
migration path for existing applications below. -->

## Other information

<!-- Please add any additional information that would help reviewers evaluate
your PR-->
