### PR TITLE
ci: disable openjdk17 from travis matrix

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "stubs/.+\\.json|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2021-11-08T17:22:15Z",
+  "generated_at": "2022-03-09T17:07:31Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -128,7 +128,7 @@
       }
     ]
   },
-  "version": "0.13.1+ibm.46.dss",
+  "version": "0.13.1+ibm.47.dss",
   "word_list": {
     "file": null,
     "hash": null

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ services:
 jdk:
   - openjdk8
   - openjdk11
-  - openjdk17
+#  - openjdk17
 
 notifications:
   email: true


### PR DESCRIPTION
## PR summary

This PR disables openjdk17 from the Travis test matrix because it is failing on installation.
## PR Checklist

Please make sure that your PR fulfills the following requirements:

- [x] The commit message follows the
[Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type  
<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [x] Build/CI related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

## What is the new behavior?
<!-- Please describe the new behavior after your change. -->

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and
migration path for existing applications below. -->

## Other information

<!-- Please add any additional information that would help reviewers evaluate
your PR-->
