### PR TITLE
Fix javadoc:

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
     </licenses>
 
     <organization>
-        <name>IBM Cloud</name>
+        <name>IBM Corporation</name>
     </organization>
 
     <scm>
@@ -439,7 +439,6 @@
                     <show>public</show>
                     <source>1.8</source>
                     <doctitle>${project.name}, version ${project.version}</doctitle>
-                    <footer>IBM Corporation</footer>
                 </configuration>
                 <executions>
                     <execution>


### PR DESCRIPTION
- Remove obsolete footer option
- Fix organization. This affects the default `-bottom` option for
  javadoc to produce something like
  "Copyright © 2022 IBM Corporation. All rights reserved."
