### PR TITLE
ci: reduce actions trigger scope for push to main only

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,7 @@
 name: test
 on:
   push:
-    branches-ignore: ['gh-pages']
+    branches: ['main']
   pull_request:
     branches-ignore: ['gh-pages']
 env:
@@ -13,7 +13,7 @@ jobs:
   test:
     strategy:
       matrix:
-        java: ['8', '11', '17'] 
+        java: ['8', '11', '17']
     runs-on: ubuntu-latest
     services:
       couchdb:


### PR DESCRIPTION
## PR summary

Currently our actions triggered twice on each PR - once for PR itself another one for push. We can reduce waste to only triggering push for main and keeping PR check.

## PR Checklist

Please make sure that your PR fulfills the following requirements:

- [x] The commit message follows the
[Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type  
<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [x] Build/CI related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

## What is the new behavior?
<!-- Please describe the new behavior after your change. -->

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and
migration path for existing applications below. -->

## Other information

<!-- Please add any additional information that would help reviewers evaluate
your PR-->
