### PR TITLE
fix: add missing operation names to path validator

### DIFF
--- a/modules/common/src/main/java/com/ibm/cloud/cloudant/internal/CloudantBaseService.java
+++ b/modules/common/src/main/java/com/ibm/cloud/cloudant/internal/CloudantBaseService.java
@@ -1,5 +1,5 @@
 /**
- * © Copyright IBM Corporation 2020, 2021. All Rights Reserved.
+ * © Copyright IBM Corporation 2020, 2022. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/common/src/main/java/com/ibm/cloud/cloudant/internal/CloudantBaseService.java
+++ b/modules/common/src/main/java/com/ibm/cloud/cloudant/internal/CloudantBaseService.java
@@ -108,6 +108,9 @@ public abstract class CloudantBaseService extends BaseService {
             Arrays.asList(
                 "deleteDocument",
                 "getDocument",
+                "getDocumentAsMixed",
+                "getDocumentAsRelated",
+                "getDocumentAsStream",
                 "headDocument",
                 "putDocument",
                 "deleteAttachment",

--- a/modules/common/src/test/java/com/ibm/cloud/cloudant/internal/ValidationTest.java
+++ b/modules/common/src/test/java/com/ibm/cloud/cloudant/internal/ValidationTest.java
@@ -42,6 +42,20 @@ public class ValidationTest {
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = ".+_testDocument.+")
+    void validatesDocumentIdWithAsStreamOperation() {
+        CloudantBaseService cloudantBaseService = new CloudantBaseService(null, new NoAuthAuthenticator()) {
+        };
+        cloudantBaseService.setServiceUrl("https://cloudant.example");
+        HttpUrl requestUrl =  HttpUrl.parse(cloudantBaseService.getServiceUrl()).newBuilder().addPathSegment(dbName).addPathSegment(docId).build();
+        Request.Builder rb = new Request.Builder().url(requestUrl).get();
+        Map<String, String> sdkHeaders = SdkCommon.getSdkHeaders("cloudant", "v1", "getDocumentAsStream");
+        for (Entry<String, String> header : sdkHeaders.entrySet()) {
+            rb.header(header.getKey(), header.getValue());
+        }
+        cloudantBaseService.createServiceCall(rb.build(), null);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = ".+_testDocument.+")
     void validatesDocumentIdAtLongServicePath() {
         CloudantBaseService cloudantBaseService = new CloudantBaseService(null, new NoAuthAuthenticator()) {
         };


### PR DESCRIPTION
## PR summary

add missing operation names to path validator

**Note: An existing issue is [required](https://github.com/IBM/cloudant-java-sdk/blob/main/CONTRIBUTING.md#PRs) before opening a PR.**

## PR Checklist

Please make sure that your PR fulfills the following requirements:

- [x] The commit message follows the
[Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type  
<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] New tests
- [ ] Build/CI related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## What is the current behavior?
Not all operations have paths validated

## What is the new behavior?
Validate paths additionally on

`getDocumentAsMixed`
`getDocumentAsRelated`
`getDocumentAsStream`

## Does this PR introduce a breaking change?

- [x] Yes - _only if previous users relied on previous behaviour_
- [ ] No

migration path: any applications which use special paths for the above operations should use the correct operation, eg one of the `*AllDocs*` methods in the case of the `_all_docs` path.

## Other information

<!-- Please add any additional information that would help reviewers evaluate
your PR-->
