### PR TITLE
Remove Java 8 in GH actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
   test:
     strategy:
       matrix:
-        java: ['8', '11', '17']
+        java: ['11', '17']
     runs-on: ubuntu-latest
     services:
       couchdb:

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
         <maven-reports-plugin-version>3.4.2</maven-reports-plugin-version>
         <maven-failsafe-plugin-version>3.0.0-M9</maven-failsafe-plugin-version>
         <maven-buildnumber-plugin-version>3.0.0</maven-buildnumber-plugin-version>
-        <mockito-version>4.11.0</mockito-version>
+        <mockito-version>5.1.1</mockito-version>
         <slf4j-version>2.0.6</slf4j-version>
 
         <!-- Set UTF-8 encoding -->

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 
         <git-repository-name>cloudant-java-sdk</git-repository-name>
 
-        <testng-version>7.4.0</testng-version>
+        <testng-version>7.7.1</testng-version>
         <okhttp3-version>4.10.0</okhttp3-version>
         <surefire-version>3.0.0-M9</surefire-version>
         <jacoco-plugin-version>0.8.8</jacoco-plugin-version>


### PR DESCRIPTION
## PR summary

<!-- please include a brief summary of the changes in this PR -->

Fixes: #369 

**Note: An existing issue is [required](https://github.com/IBM/cloudant-java-sdk/blob/main/CONTRIBUTING.md#PRs) before opening a PR.**

## PR Checklist

Please make sure that your PR fulfills the following requirements:

- [x] The commit message follows the
[Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type  
<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [x] Build/CI related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## What is the current behavior?
We currently run tests against Java 8, 11, and 17 with GH actions.  The test suite requires `testng` and `mockito` packages.  The latest version of both of these packages supports Java 11 and greater.  For us to upgrade, we need to remove Java 8 from the GHA matrix.
<!-- Please describe the current behavior that you are modifying. -->

## What is the new behavior?
Remove Java 8 from GH actions.
<!-- Please describe the new behavior after your change. -->

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and
migration path for existing applications below. -->

## Other information

<!-- Please add any additional information that would help reviewers evaluate
your PR-->
