### PR TITLE
Revert okio dependency and bump sdk-core

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
     <packaging>pom</packaging>
 
     <properties>
-        <sdk-core-version>9.18.4</sdk-core-version>
+        <sdk-core-version>9.18.5</sdk-core-version>
 
         <git-repository-name>cloudant-java-sdk</git-repository-name>
 


### PR DESCRIPTION
## PR summary

Revert temporary direct dependency on `okio` `3.4.0` and bump `sdk-core` to `9.18.5` that moved `okio` dep on `3.5.0`

## PR Checklist

Please make sure that your PR fulfills the following requirements:

- [] The commit message follows the
[Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type  
<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [x] Build/CI related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

## What is the new behavior?
<!-- Please describe the new behavior after your change. -->

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and
migration path for existing applications below. -->

## Other information

<!-- Please add any additional information that would help reviewers evaluate
your PR-->
