### PR TITLE
build(javadoc): skip examples module from Javadoc

### DIFF
--- a/scripts/javadoc/publish-doc.sh
+++ b/scripts/javadoc/publish-doc.sh
@@ -8,7 +8,7 @@ GIT_REPO=$(git remote get-url origin)
 
 # Create documentation
 printf ">>>>> Generate new documentation\n"
-mvn javadoc:aggregate
+mvn javadoc:aggregate -pl '!modules/examples'
 
 # Clone gh-pages branch
 printf ">>>>> Publishing javadoc for release build: repo=%s branch=%s build_num=%s job_name=%s\n" ${GIT_REPO} ${BRANCH_NAME} ${BUILD_NUMBER} ${JOB_NAME}


### PR DESCRIPTION
## PR summary

fixes #512 


**Note: An existing issue is [required](https://github.com/IBM/cloudant-java-sdk/blob/main/CONTRIBUTING.md#PRs) before opening a PR.**

## PR Checklist

Please make sure that your PR fulfills the following requirements:

- [x] The commit message follows the
[Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type  
<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [x] Build/CI related changes
- [x] Documentation content changes
- [ ] Other (please describe)

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->
Javadoc displays `features` on main page.

## What is the new behavior?
<!-- Please describe the new behavior after your change. -->

Javadoc does not display `features` on main page.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and
migration path for existing applications below. -->

## Other information

<!-- Please add any additional information that would help reviewers evaluate
your PR-->

I tested this locally and now I cannot see it:
![image](https://github.com/IBM/cloudant-java-sdk/assets/17944122/3aae111a-1648-46e7-8860-189ae0318587)

