### PR TITLE
Revert "build: skip javadoc generation for examples module"

### DIFF
--- a/modules/examples/pom.xml
+++ b/modules/examples/pom.xml
@@ -35,20 +35,6 @@
         </dependency>
     </dependencies>
 
-    <build>
-        <pluginManagement>
-            <plugins>
-              <plugin>
-              <groupId>org.apache.maven.plugins</groupId>
-              <artifactId>maven-javadoc-plugin</artifactId>
-              <version>${maven-javadoc-plugin-version}</version>
-              <configuration>
-                  <skip>true</skip>
-              </configuration>
-              </plugin>
-            </plugins>
-        </pluginManagement>
-    </build>
     <developers>
         <developer>
             <name>IBM Cloudant</name>


### PR DESCRIPTION
## PR summary

This reverts commit a5f780d8499cb8d4a63253981df9a4dd5f9c78fa.

**Note: An existing issue is [required](https://github.com/IBM/cloudant-java-sdk/blob/main/CONTRIBUTING.md#PRs) before opening a PR.**

## PR Checklist

Please make sure that your PR fulfills the following requirements:

- [ ] The commit message follows the
[Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type  
<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [ ] Build/CI related changes
- [ ] Documentation content changes
- [x] Other (please describe) - revert 

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

Javadoc skip prevents publication of examples module.

## What is the new behavior?
<!-- Please describe the new behavior after your change. -->

Reverting the commit creates javadoc for the examples module again.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and
migration path for existing applications below. -->

## Other information

<!-- Please add any additional information that would help reviewers evaluate
your PR-->
