### PR TITLE
build: disable javadoc warnings for examples module

### DIFF
--- a/modules/examples/pom.xml
+++ b/modules/examples/pom.xml
@@ -35,6 +35,18 @@
         </dependency>
     </dependencies>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>${maven-javadoc-plugin-version}</version>
+                <configuration>
+                    <doclint>all,-missing</doclint>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
     <developers>
         <developer>
             <name>IBM Cloudant</name>


### PR DESCRIPTION
## PR summary

<!-- please include a brief summary of the changes in this PR -->

Disable `javadoc` warnings for examples module.

## PR Checklist

Please make sure that your PR fulfills the following requirements:

- [x] The commit message follows the
[Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type  
<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [x] Build/CI related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

## What is the new behavior?
<!-- Please describe the new behavior after your change. -->

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and
migration path for existing applications below. -->

## Other information

<!-- Please add any additional information that would help reviewers evaluate
your PR-->
