### PR TITLE
docs: fix javadoc cross-linking to sdk-core

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -277,6 +277,9 @@
                     <version>${maven-javadoc-plugin-version}</version>
                     <configuration>
                         <quiet>true</quiet>
+                        <links>
+                            <link>https://ibm.github.io/java-sdk-core/docs/${sdk-core-version}/</link>
+                        </links>
                     </configuration>
                     <executions>
                         <execution>


### PR DESCRIPTION
## PR summary

In our Javadoc we can't follow links to the `java-sdk-core` (e.g. `ServiceCall`) from here:
https://ibm.github.io/cloudant-java-sdk/docs/0.9.1/com/ibm/cloud/cloudant/v1/Cloudant.html#getSessionInformation()

This PR configures the links maven parameter to `https://ibm.github.io/java-sdk-core/docs/${sdk-core-version}`.

## PR Checklist

Please make sure that your PR fulfills the following requirements:

- [x] The commit message follows the
[Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type  
<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [x] Build/CI related changes
- [x] Documentation content changes
- [ ] Other (please describe)

## What is the current behavior?

![image](https://github.com/user-attachments/assets/c8fd2c65-f6e6-4df6-b7b5-b7afed630a4b)

## What is the new behavior?

![image](https://github.com/user-attachments/assets/1fef8735-578f-4fc7-8392-c25223233f0a)

^ this link directs me to https://ibm.github.io/java-sdk-core/docs/9.21.1/com/ibm/cloud/sdk/core/http/ServiceCall.html?is-external=true

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and
migration path for existing applications below. -->

## Other information

<!-- Please add any additional information that would help reviewers evaluate
your PR-->
