### PR TITLE
test: fix assertion order in session tests

### DIFF
--- a/modules/common/src/test/java/com/ibm/cloud/cloudant/internal/TestCloudantService.java
+++ b/modules/common/src/test/java/com/ibm/cloud/cloudant/internal/TestCloudantService.java
@@ -14,7 +14,6 @@
 package com.ibm.cloud.cloudant.internal;
 
 import com.ibm.cloud.cloudant.common.SdkCommon;
-import com.ibm.cloud.cloudant.internal.CloudantBaseService;
 import com.ibm.cloud.sdk.core.http.RequestBuilder;
 import com.ibm.cloud.sdk.core.http.ResponseConverter;
 import com.ibm.cloud.sdk.core.http.ServiceCall;


### PR DESCRIPTION
## PR summary

<!-- please include a brief summary of the changes in this PR -->
Some minor clean ups  in the session tests.

Associated with s681 and #599 

## PR Checklist

Please make sure that your PR fulfills the following requirements:

- [x] The commit message follows the
[Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type  
<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [x] Build/CI related changes - test cleanup
- [ ] Documentation content changes
- [ ] Other (please describe)

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

When reviewing  #599 I noticed that some of the test assertion expected/actual were reversed. This gave confusing messages when tests failed.

## What is the new behavior?
<!-- Please describe the new behavior after your change. -->

* Correct the assertion method arg order to give correct messages
* Remove unused import
* `MockWebServer` is a `Closeable` so we can use try-with-resources for a cleaner test

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and
migration path for existing applications below. -->

## Other information

<!-- Please add any additional information that would help reviewers evaluate
your PR-->
