### PR TITLE
feat: improve error response messages

### DIFF
--- a/modules/cloudant/src/test/java/com/ibm/cloud/cloudant/v1/CloudantErrorInterceptorTest.java
+++ b/modules/cloudant/src/test/java/com/ibm/cloud/cloudant/v1/CloudantErrorInterceptorTest.java
@@ -1,0 +1,168 @@
+package com.ibm.cloud.cloudant.v1;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+
+import java.util.function.Consumer;
+import java.util.function.Function;
+import org.testng.annotations.Test;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import com.ibm.cloud.cloudant.v1.model.GetDocumentOptions;
+import com.ibm.cloud.cloudant.v1.model.HeadDocumentOptions;
+import com.ibm.cloud.sdk.core.security.NoAuthAuthenticator;
+import com.ibm.cloud.sdk.core.service.exception.ServiceResponseException;
+import com.ibm.cloud.sdk.core.util.GsonSingleton;
+
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+
+public class CloudantErrorInterceptorTest {
+
+  private static final String REQ_ID = "338da230c5";
+  private static final String EXPECTED_ERROR = "test_error_name";
+  private static final String EXPECTED_REASON = "test reason";
+  private static final String MOCK_RESPONSE_BODY = "{\"error\":\"" + EXPECTED_ERROR+ "\",\"reason\":\"" + EXPECTED_REASON + "\"}";
+
+  public void runTest(
+        MockResponse mockResponse,
+        Function<Cloudant, ?> serviceCall,
+        Consumer<JsonObject> bodyAssertion
+      ) throws Exception {
+    try(MockWebServer server = new MockWebServer()) {
+      server.start();
+      server.enqueue(mockResponse);
+      Cloudant cloudantService = new Cloudant("test", new NoAuthAuthenticator());
+      cloudantService.setServiceUrl(server.url("/test/foo").toString());
+      try {
+        serviceCall.apply(cloudantService);
+      } catch(ServiceResponseException sre) {
+        JsonObject errorBody = null;
+        String body = sre.getResponseBody();
+        if (body != null) {
+          errorBody = GsonSingleton.getGson().fromJson(body, JsonObject.class);
+        }
+        bodyAssertion.accept(errorBody);
+      }
+    }
+  }
+
+  class AssertAugment implements Consumer<JsonObject> {
+
+    @Override
+    public void accept(JsonObject actualErrorBody) {
+      assertNotNull(actualErrorBody, "There should be a body.");
+      assertTrue(actualErrorBody.has("errors"));
+      JsonArray errors = actualErrorBody.getAsJsonArray("errors");
+      assertEquals(1, errors.size());
+      JsonObject error = errors.get(0).getAsJsonObject();
+      assertTrue(error.has("code"));
+      assertTrue(error.has("message"));
+      assertEquals(error.get("code").getAsString(), EXPECTED_ERROR);
+      assertEquals(error.get("message").getAsString(), EXPECTED_ERROR + ": " + EXPECTED_REASON);
+      assertTrue(actualErrorBody.has("trace"));
+      assertEquals(actualErrorBody.get("trace").getAsString(), REQ_ID);
+    }
+
+  }
+
+  class AssertNoAugment implements Consumer<JsonObject> {
+
+    @Override
+    public void accept(JsonObject actualErrorBody) {
+      assertNotNull(actualErrorBody, "There should be a body.");
+      assertFalse(actualErrorBody.has("errors"));
+      assertFalse(actualErrorBody.has("trace"));
+    }
+    
+  }
+
+  class AssertNoBody implements Consumer<JsonObject> {
+
+    @Override
+    public void accept(JsonObject actualErrorBody) {
+      assertNull(actualErrorBody, "There should be no body.");
+    }
+    
+  }
+
+  @Test
+  public void testDocumentNoError() throws Throwable {
+    // Register a mock response
+    MockResponse mockResponse = new MockResponse()
+      .setHeader("Content-type", "application/json")
+      .setHeader("x-couch-request-id", REQ_ID)
+      .setResponseCode(200)
+      .setBody("{\"_id\": \"foo\"}");
+
+      GetDocumentOptions opts = new GetDocumentOptions.Builder()
+      .db("test")
+      .docId("foo")
+      .build();
+
+    runTest(mockResponse,
+      c -> c.getDocument(opts).execute(),
+      new AssertNoAugment());
+  }
+
+  @Test
+  public void testDocumentError() throws Throwable {
+    // Register a mock response
+    MockResponse mockResponse = new MockResponse()
+      .setHeader("Content-type", "application/json")
+      .setHeader("x-couch-request-id", REQ_ID)
+      .setResponseCode(444)
+      .setBody(MOCK_RESPONSE_BODY);
+
+      GetDocumentOptions opts = new GetDocumentOptions.Builder()
+      .db("test")
+      .docId("foo")
+      .build();
+
+    runTest(mockResponse,
+      c -> c.getDocument(opts).execute(),
+      new AssertAugment());
+  }
+
+  @Test
+  public void testDocumentAsStreamError() throws Throwable {
+    // Register a mock response
+    
+    MockResponse mockResponse = new MockResponse()
+      .setHeader("Content-type", "application/json")
+      .setHeader("x-couch-request-id", REQ_ID)
+      .setResponseCode(444)
+      .setChunkedBody(MOCK_RESPONSE_BODY, 1);
+
+      GetDocumentOptions opts = new GetDocumentOptions.Builder()
+      .db("test")
+      .docId("foo")
+      .build();
+
+    runTest(mockResponse,
+      c -> c.getDocumentAsStream(opts).execute(),
+      new AssertAugment());
+  }
+
+
+  @Test
+  public void testDocumentHeadError() throws Throwable {
+    // Register a mock response
+    MockResponse mockResponse = new MockResponse()
+      .setHeader("Content-type", "application/json")
+      .setHeader("x-couch-request-id", REQ_ID)
+      .setResponseCode(444);
+
+      HeadDocumentOptions opts = new HeadDocumentOptions.Builder()
+      .db("test")
+      .docId("foo")
+      .build();
+
+    runTest(mockResponse,
+      c -> c.headDocument(opts).execute(),
+      new AssertNoBody());
+  }
+}

--- a/modules/common/src/main/java/com/ibm/cloud/cloudant/internal/ErrorTransformInterceptor.java
+++ b/modules/common/src/main/java/com/ibm/cloud/cloudant/internal/ErrorTransformInterceptor.java
@@ -1,0 +1,91 @@
+/**
+ * © Copyright IBM Corporation 2024. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.ibm.cloud.cloudant.internal;
+
+import java.io.IOException;
+import java.util.Optional;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+import com.ibm.cloud.sdk.core.util.GsonSingleton;
+
+import okhttp3.Interceptor;
+import okhttp3.Response;
+import okhttp3.ResponseBody;
+
+public class ErrorTransformInterceptor implements Interceptor {
+
+    @Override
+    public Response intercept(Chain chain) throws IOException {
+        // Don't modify the request, but get the response
+        Response response = chain.proceed(chain.request());
+        if (!response.isSuccessful() // skip successful responses
+            && response.body() != null // skip cases with no body
+            && response.body().contentType() != null // skip cases with no content type
+            && "application".equals(response.body().contentType().type())
+            && "json".equals(response.body().contentType().subtype()) // we only want to work with application/json
+        ) {
+            String errorResponse = response.body().string();
+            JsonObject errorBody = null;
+            try {
+                errorBody = GsonSingleton.getGson().fromJson(errorResponse, JsonObject.class);
+                if (errorBody != null) {
+                    // Don't augment if there is already a trace present
+                    if (!errorBody.has("trace")) {
+                        if (!errorBody.has("errors")) {
+                            String error = Optional.ofNullable(errorBody.get("error")).map(JsonElement::getAsString).orElse(null);
+                            String reason = Optional.ofNullable(errorBody.get("reason")).map(JsonElement::getAsString).orElse(null);
+                            if (error != null) {
+                                // Augment with errors array model
+                                JsonObject errorModel = new JsonObject();
+                                errorModel.addProperty("code", error);
+                                StringBuilder messageBuilder = new StringBuilder(error);
+                                if (reason != null && !reason.isEmpty()) {
+                                    messageBuilder.append(": ");
+                                    messageBuilder.append(reason);
+                                }
+                                errorModel.addProperty("message", messageBuilder.toString());
+                                JsonArray errors = new JsonArray(1);
+                                errors.add(errorModel);
+                                errorBody.getAsJsonObject().add("errors", errors);
+                                // Propose the new augmented response, it may be augmented again by trace
+                                errorResponse = errorBody.toString();
+                            }
+                        }
+                        if (errorBody.has("errors")) {
+                            String trace = response.header("x-couch-request-id");
+                            if (trace != null && !trace.isEmpty()) {
+                                // Augment with trace
+                                errorBody.addProperty("trace", trace);
+                                // Propose the new augmented response
+                                errorResponse = errorBody.toString();
+                            }
+                        }
+                    }
+                }
+            } catch (JsonParseException e) {
+              // If response body is malformed, just return the original response
+            }
+            // Make a new body to return, either using the original repsonse or
+            // the modified one.
+            response = response
+                        .newBuilder()
+                        .body(ResponseBody.create(errorResponse,
+                            response.body().contentType()))
+                        .build();
+        }
+        return response;
+    }
+}

--- a/modules/common/src/test/java/com/ibm/cloud/cloudant/internal/ErrorTransformInterceptorTest.java
+++ b/modules/common/src/test/java/com/ibm/cloud/cloudant/internal/ErrorTransformInterceptorTest.java
@@ -1,0 +1,380 @@
+/**
+ * © Copyright IBM Corporation 2024. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.ibm.cloud.cloudant.internal;
+
+import okhttp3.Interceptor;
+import okhttp3.Interceptor.Chain;
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.Protocol;
+import okhttp3.Request;
+import okhttp3.Response;
+import okhttp3.ResponseBody;
+
+import java.io.IOException;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.util.Iterator;
+import java.util.EnumSet;
+
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.AfterTest;
+import org.testng.annotations.Test;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import com.ibm.cloud.sdk.core.security.NoAuthAuthenticator;
+import com.ibm.cloud.sdk.core.util.GsonSingleton;
+import static org.junit.Assert.assertNull;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+public class ErrorTransformInterceptorTest {
+
+
+    private static final String MOCK_ERROR = "test_error";
+    private static final String MOCK_ERROR_K = "error";
+    private static final String MOCK_REASON = "some test reason";
+    private static final String MOCK_REASON_K = "reason";
+    private static final String MOCK_REQ_ID = "338da230c5";
+    private static final String MOCK_MALFORMED_RESPONSE;
+    private static final String MOCK_EXPECTED_ERROR_REASON_RESPONSE;
+    private static final String MOCK_EXPECTED_ERRORS_RESPONSE;
+    private static final String MOCK_EXPECTED_NO_ERROR_RESPONSE;
+    private static final String MOCK_EXPECTED_NO_REASON_RESPONSE;
+    private static final String MOCK_EXPECTED_OK_RESPONSE;
+    private static final String MOCK_EXISTING_TRACE_RESPONSE;
+    private static final String MOCK_EXPECTED_ERROR_EMPTY_REASON_RESPONSE;
+
+    static {
+      JsonObject errorBody = new JsonObject();
+      // Add an error
+      errorBody.addProperty(MOCK_ERROR_K, MOCK_ERROR);
+      MOCK_EXPECTED_NO_REASON_RESPONSE = errorBody.toString();
+
+      errorBody.addProperty(MOCK_REASON_K, "");
+      MOCK_EXPECTED_ERROR_EMPTY_REASON_RESPONSE = errorBody.toString();
+      
+      errorBody.remove(MOCK_REASON_K);
+      errorBody.addProperty(MOCK_REASON_K, MOCK_REASON);
+      MOCK_EXPECTED_ERROR_REASON_RESPONSE = errorBody.toString();
+
+      errorBody.remove(MOCK_ERROR_K);
+      MOCK_EXPECTED_NO_ERROR_RESPONSE = errorBody.toString();
+
+      JsonObject okBody = new JsonObject();
+      okBody.addProperty("ok", true);
+      MOCK_EXPECTED_OK_RESPONSE = okBody.toString();
+
+      JsonObject errorsBody = new JsonObject();
+      errorsBody.addProperty(MOCK_ERROR_K, "wrong");
+      errorsBody.addProperty(MOCK_REASON_K, "different");
+      JsonArray errors = new JsonArray();
+      JsonObject existingError = new JsonObject();
+      existingError.addProperty("code", "not_found");
+      existingError.addProperty("message", "not_found: Database does not exist.");
+      errors.add(existingError);
+      errorsBody.add("errors", errors);
+      MOCK_EXPECTED_ERRORS_RESPONSE = errorsBody.toString();
+
+      JsonObject traceBody = new JsonObject();
+      traceBody.addProperty(MOCK_ERROR_K, "uhoh");
+      traceBody.addProperty("trace", "45566afdec");
+      MOCK_EXISTING_TRACE_RESPONSE = traceBody.toString();
+
+      MOCK_MALFORMED_RESPONSE = MOCK_EXPECTED_ERROR_REASON_RESPONSE.substring(
+        0, MOCK_EXPECTED_ERROR_REASON_RESPONSE.length() - 1);
+    }
+
+    private enum Case {
+      NO_AUGMENT_SUCCESS(200,
+        "GET",
+        MOCK_EXPECTED_OK_RESPONSE,
+        true,
+        null,
+        null,
+        null,
+        "application/json"),
+      NO_AUGMENT_REASON(444,
+        "GET",
+        MOCK_EXPECTED_NO_ERROR_RESPONSE,
+        false,
+        null,
+        null,
+        null,
+        "application/json"),
+      AUGMENT_ERROR(444,
+        "GET",
+        MOCK_EXPECTED_NO_REASON_RESPONSE,
+        false,
+        MOCK_ERROR,
+        null,
+        null,
+        "application/json"),
+      AUGMENT_ERROR_REASON(444,
+        "GET",
+        MOCK_EXPECTED_ERROR_REASON_RESPONSE,
+        false,
+        MOCK_ERROR,
+        MOCK_REASON,
+        null,
+        "application/json"),
+      NO_AUGMENT_ID_ONLY(444,
+        "GET",
+        MOCK_EXPECTED_OK_RESPONSE,
+        true,
+        null,
+        null,
+        null,
+        "application/json"),
+      NO_AUGMENT_NO_ERROR(444,
+        "GET",
+        MOCK_EXPECTED_NO_ERROR_RESPONSE,
+        true,
+        null,
+        null,
+        null,
+        "application/json"),
+      AUGMENT_ERROR_WITH_TRACE(444,
+        "GET",
+        MOCK_EXPECTED_NO_REASON_RESPONSE,
+        true,
+        MOCK_ERROR,
+        null,
+        MOCK_REQ_ID,
+        "application/json"),
+      AUGMENT_ERROR_REASON_WITH_TRACE(444,
+        "GET",
+        MOCK_EXPECTED_ERROR_REASON_RESPONSE,
+        true,
+        MOCK_ERROR,
+        MOCK_REASON,
+        MOCK_REQ_ID,
+        "application/json"),
+      NO_AUGMENT_EXISTING_TRACE(444,
+        "GET",
+        MOCK_EXISTING_TRACE_RESPONSE,
+        true,
+        null,
+        null,
+        "45566afdec",
+        "application/json"),
+      NO_AUGMENT_EXISTING_ERRORS_NO_ID(444,
+        "GET",
+        MOCK_EXPECTED_ERRORS_RESPONSE,
+        false,
+        null,
+        null,
+        null,
+        "application/json"),
+      AUGMENT_TRACE_EXISTING_ERRORS(444,
+        "GET",
+        MOCK_EXPECTED_ERRORS_RESPONSE,
+        true,
+        null,
+        null,
+        MOCK_REQ_ID,
+        "application/json"),
+      NO_AUGMENT_HEAD(444,
+        "HEAD",
+        null,
+        true,
+        null,
+        null,
+        null,
+        "application/json"),
+      NO_AUGMENT_NON_JSON(444,
+        "GET",
+        "text body",
+        true,
+        null,
+        null,
+        null,
+        "text/plain"),
+      NO_AUGMENT_NO_CONTENT_TYPE(444,
+        "GET",
+        MOCK_EXPECTED_ERROR_REASON_RESPONSE,
+        true,
+        null,
+        null,
+        null,
+        null),
+      NO_AUGMENT_MALFORMED_JSON(444,
+        "GET",
+        MOCK_MALFORMED_RESPONSE,
+        true,
+        null,
+        null,
+        null,
+        "application/json"),
+      AUGMENT_ERROR_EMPTY_REASON_WITH_TRACE(444,
+        "GET",
+        MOCK_EXPECTED_ERROR_EMPTY_REASON_RESPONSE,
+        true,
+        MOCK_ERROR,
+        null,
+        MOCK_REQ_ID,
+        "application/json");
+
+      private final Response mockResponse;
+      private final Request mockRequest;
+      private final String responseBody;
+      private final String errorToAssert;
+      private final String reasonToAssert;
+      private final String traceToAssert;
+
+      Case(int statusCode,
+            String httpMethod,
+            String responseBody,
+            boolean applyIdHeader,
+            String errorToAssert,
+            String reasonToAssert,
+            String traceToAssert,
+            String contentType) {
+              this.responseBody = responseBody;
+              this.errorToAssert = errorToAssert;
+              this.reasonToAssert = reasonToAssert;
+              this.traceToAssert = traceToAssert;
+        mockRequest = new Request.Builder()
+          .url("https://test.example")
+          .method(httpMethod, null)
+          .build();
+        // Make a response
+        Response.Builder responseBuilder = new Response.Builder()
+          .protocol(Protocol.HTTP_2)
+          .code(statusCode)
+          .message("status_line")
+          .request(mockRequest);
+        // Make a response body
+        if (responseBody != null) {
+          MediaType bodyContentType = (contentType != null) ? MediaType.parse(contentType) : null;
+          responseBuilder.body(ResponseBody.create(responseBody, bodyContentType));
+        }
+        // Add the header if needed
+        if (applyIdHeader) {
+          responseBuilder.header("x-couch-request-id", MOCK_REQ_ID);
+        }
+        mockResponse = responseBuilder.build();
+      }
+
+      void runTest(Interceptor interceptor) throws IOException {
+        Response r = interceptor.intercept(mockChain(mockRequest, mockResponse));
+        if (errorToAssert != null || traceToAssert != null) {
+          JsonObject actualErrorBody = GsonSingleton.getGson().fromJson(
+            r.body().string(), JsonObject.class);
+          if (errorToAssert != null) {
+            StringBuilder expectedMessage = new StringBuilder(errorToAssert);
+            assertEquals(actualErrorBody.get("error").getAsString(), errorToAssert);
+            if (reasonToAssert != null) {
+              expectedMessage.append(": ");
+              expectedMessage.append(reasonToAssert);
+              assertEquals(actualErrorBody.get("reason").getAsString(), reasonToAssert);
+            }
+            assertTrue(actualErrorBody.has("errors"), "There should be an errors array present.");
+            JsonArray errorsArray = actualErrorBody.get("errors").getAsJsonArray();
+            assertEquals(errorsArray.size(), 1);
+            JsonObject errorItem = errorsArray.get(0).getAsJsonObject();
+            assertEquals(errorItem.get("code").getAsString(), errorToAssert);
+            assertEquals(errorItem.get("message").getAsString(), expectedMessage.toString());
+          } else {
+            // If the response body already had errors then it will still have it
+            if (!responseBody.contains("errors")) {
+              assertFalse(actualErrorBody.has("errors"), "There should not be an errors array present.");
+            }
+          }
+          if (traceToAssert != null) {
+            assertTrue(actualErrorBody.has("trace"), "There should be a trace element present.");
+            assertEquals(actualErrorBody.get("trace").getAsString(), traceToAssert);
+          } else {
+            assertFalse(actualErrorBody.has("trace"), "There should not be a trace element present.");
+          }
+        } else {
+          // If we aren't asserting a specific part of augment check the body is unchanged
+          if ("HEAD" == r.request().method()) {
+            assertNull(r.body());
+          } else {
+            assertEquals(r.body().string(), responseBody); 
+          }
+        }
+      }
+
+      @DataProvider(name = "cases")
+      public static Iterator<Case> parameters() {
+        return EnumSet.allOf(Case.class).iterator();
+      }
+    }
+
+    private ErrorTransformInterceptor interceptor;
+
+    @BeforeTest
+    public void setUp() throws IOException {
+        // Initialize the custom error interceptor
+        interceptor = new ErrorTransformInterceptor();
+    }
+
+    @AfterTest
+    void tearDown() throws IOException {
+      interceptor = null;
+    }
+
+    public static Chain mockChain(Request req, Response resp) {
+      return (Chain) Proxy.newProxyInstance(
+        ErrorTransformInterceptorTest.class.getClassLoader(),
+        new Class[]{Chain.class},
+        new InvocationHandler() {
+        @Override
+        public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+          switch (method.getName()) {
+            case "proceed":
+              return resp;
+            case "request":
+              return req;
+            default:
+              throw new UnsupportedOperationException("Mock does not implement method " + method.getName());
+          }
+        }
+      });
+  }
+
+  @Test(dataProvider = "cases", dataProviderClass = Case.class)
+  public void testInterceptor(Case c) throws Exception {
+    c.runTest(interceptor);
+  }
+
+  private void countExpectedInterceptors(CloudantBaseService service) {
+    int count = 0;
+    for (Interceptor interceptor : service.getClient().interceptors()) {
+      if (interceptor instanceof ErrorTransformInterceptor) {
+        count++;
+      }
+    }
+    assertEquals(count, 1);
+  }
+  @Test
+  public void testSetClientWithInterceptor() throws Throwable {
+    CloudantBaseService cloudantService = new CloudantBaseService("test", new NoAuthAuthenticator()) {};
+    cloudantService.setClient(cloudantService.getClient());
+    countExpectedInterceptors(cloudantService);
+  }
+
+  @Test
+  public void testSetClientWithNoInterceptor() throws Throwable {
+    CloudantBaseService cloudantService = new CloudantBaseService("test", new NoAuthAuthenticator()) {};
+    OkHttpClient newClient = new OkHttpClient();
+    cloudantService.setClient(newClient);
+    countExpectedInterceptors(cloudantService);
+  }
+}


### PR DESCRIPTION
## PR summary

Add interceptor for error response augmentation

Fixes: s1002

**Note: An existing issue is [required](https://github.com/IBM/cloudant-java-sdk/blob/main/CONTRIBUTING.md#PRs) before opening a PR.**

## PR Checklist

Please make sure that your PR fulfills the following requirements:

- [x] The commit message follows the
[Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type  
<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [ ] Build/CI related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

Cloudant/CouchDB error models are handled by the core with only the `error` field being processed. Obtaining e.g. the `reason` field requires additional user code.

## What is the new behavior?
<!-- Please describe the new behavior after your change. -->

The error response is augmented with `errors` and `trace` properties.
This improves the way the core handles the error response and enhances the user facing exception string to include the `reason`.
The `trace` is the CouchDB request ID which can be used to correlate with logs.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

The existing error model fields are retained, the new fields are backwards compatible.
Exception strings will be different, but the types remain the same.

<!-- If this PR contains a breaking change, please describe the impact and
migration path for existing applications below. -->

## Other information

<!-- Please add any additional information that would help reviewers evaluate
your PR-->

Add `ErrorTransformInterceptor`.
Modify `CloudantBaseService` to apply interceptor.
New tests in `ErrorTransformInterceptorTest` and `CloudantErrorInterceptorTest`.
