### PR TITLE
feat: set x-request-id as error trace

### DIFF
--- a/modules/common/src/main/java/com/ibm/cloud/cloudant/internal/ErrorTransformInterceptor.java
+++ b/modules/common/src/main/java/com/ibm/cloud/cloudant/internal/ErrorTransformInterceptor.java
@@ -65,7 +65,10 @@ public class ErrorTransformInterceptor implements Interceptor {
                             }
                         }
                         if (errorBody.has("errors")) {
-                            String trace = response.header("x-couch-request-id");
+                            String trace = response.header("x-request-id");
+                            if (trace == null || trace.isEmpty()) {
+                                trace = response.header("x-couch-request-id");
+                            }
                             if (trace != null && !trace.isEmpty()) {
                                 // Augment with trace
                                 errorBody.addProperty("trace", trace);


### PR DESCRIPTION
## PR summary

<!-- please include a brief summary of the changes in this PR -->

If the `x-request-id` header is on a response use it to set the error `trace` field (in preference to `x-couch-request-id`, but still use `x-couch-request-id` if there is no `x-request-id`).

Fixes: part of s1037

**Note: An existing issue is [required](https://github.com/IBM/cloudant-java-sdk/blob/main/CONTRIBUTING.md#PRs) before opening a PR.**

## PR Checklist

Please make sure that your PR fulfills the following requirements:

- [x] The commit message follows the
[Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type  
<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [ ] Build/CI related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

The error `trace` introduced in #614 only handles CouchDB's `x-couch-request-id` header on responses.

## What is the new behavior?
<!-- Please describe the new behavior after your change. -->

The error `trace` also handles `x-request-id` header on responses.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and
migration path for existing applications below. -->

## Other information

<!-- Please add any additional information that would help reviewers evaluate
your PR-->
