### PR TITLE
fix: assign since correctly in changes follower

### DIFF
--- a/modules/cloudant/src/main/java/com/ibm/cloud/cloudant/features/ChangesResultSpliterator.java
+++ b/modules/cloudant/src/main/java/com/ibm/cloud/cloudant/features/ChangesResultSpliterator.java
@@ -96,7 +96,8 @@ class ChangesResultSpliterator extends AbstractSpliterator<ChangesResult> {
         } else {
             this.transientSuppression = TransientErrorSuppression.TIMER;
         }
-        if (this.options.since() == null) {
+        this.since = this.options.since();
+        if (this.since == null) {
             this.since = (this.mode == Mode.LISTEN) ? "now" : "0";
         }
         this.successTimestamp = Instant.now();


### PR DESCRIPTION
## PR summary

<!-- please include a brief summary of the changes in this PR -->

Assign `since` correctly when initializing `ChangesResultSpliterator`

Fixes: #629

**Note: An existing issue is [required](https://github.com/IBM/cloudant-java-sdk/blob/main/CONTRIBUTING.md#PRs) before opening a PR.**

## PR Checklist

Please make sure that your PR fulfills the following requirements:

- [x] The commit message follows the
[Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type  
<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [ ] Build/CI related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

`this.since` is used when copying the options for the request, but `this.since` is only set for the default `null` cases.

## What is the new behavior?
<!-- Please describe the new behavior after your change. -->

Set `this.since` to `this.options.since()` and only then apply the defaults if necessary.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and
migration path for existing applications below. -->

## Other information

<!-- Please add any additional information that would help reviewers evaluate
your PR-->
