### PR TITLE
test: move CloudantErrorInterceptorTest class to internal package

### DIFF
--- a/modules/cloudant/src/test/java/com/ibm/cloud/cloudant/internal/CloudantErrorInterceptorTest.java
+++ b/modules/cloudant/src/test/java/com/ibm/cloud/cloudant/internal/CloudantErrorInterceptorTest.java
@@ -1,4 +1,4 @@
-package com.ibm.cloud.cloudant.v1;
+package com.ibm.cloud.cloudant.internal;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
@@ -11,6 +11,7 @@ import java.util.function.Function;
 import org.testng.annotations.Test;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
+import com.ibm.cloud.cloudant.v1.Cloudant;
 import com.ibm.cloud.cloudant.v1.model.GetDocumentOptions;
 import com.ibm.cloud.cloudant.v1.model.HeadDocumentOptions;
 import com.ibm.cloud.sdk.core.security.NoAuthAuthenticator;


### PR DESCRIPTION
## PR summary

<!-- please include a brief summary of the changes in this PR -->
Move `CloudantErrorInterceptorTest` test class from `v1` to new `internal` package

Fixes: related to s1002

**Note: An existing issue is [required](https://github.com/IBM/cloudant-java-sdk/blob/main/CONTRIBUTING.md#PRs) before opening a PR.**

## PR Checklist

Please make sure that your PR fulfills the following requirements:

- [ ] The commit message follows the
[Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type  
<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [ ] Build/CI related changes
- [ ] Documentation content changes
- [x] Other: move test file

## What is the current behavior?
Test class is under the generated `v1` directory.  Given that this is not a generated test class, it will get deleted in the next PR generated by our CI pipeline.
<!-- Please describe the current behavior that you are modifying. -->

## What is the new behavior?
Move the test class to `internal` package.
<!-- Please describe the new behavior after your change. -->

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and
migration path for existing applications below. -->

## Other information

<!-- Please add any additional information that would help reviewers evaluate
your PR-->
