### PR TITLE
perf: use normal feed for one-off changes

### DIFF
--- a/modules/cloudant/src/main/java/com/ibm/cloud/cloudant/features/ChangesFollower.java
+++ b/modules/cloudant/src/main/java/com/ibm/cloud/cloudant/features/ChangesFollower.java
@@ -257,7 +257,7 @@ public class ChangesFollower {
             // Construct the spliterator using the batch size as the per request limit
             this.changesResultSpliterator.set(new ChangesResultSpliterator(
                 this.client,
-                ChangesOptionsHelper.cloneOptionsWithNewLimit(this.options, batchSize.get()),
+                ChangesOptionsHelper.cloneOptionsWithModeAndNewLimit(this.options, mode, batchSize.get()),
                 mode,
                 this.errorTolerance
             ));

--- a/modules/cloudant/src/test/java/com/ibm/cloud/cloudant/features/ChangesResultSpliteratorTest.java
+++ b/modules/cloudant/src/test/java/com/ibm/cloud/cloudant/features/ChangesResultSpliteratorTest.java
@@ -40,8 +40,9 @@ import org.testng.annotations.Test;
 public class ChangesResultSpliteratorTest {
 
     // A default set of options to run with
-    static final PostChangesOptions DEFAULT_OPTIONS = ChangesOptionsHelper.cloneOptionsWithNewLimit(
+    static final PostChangesOptions DEFAULT_OPTIONS = ChangesOptionsHelper.cloneOptionsWithModeAndNewLimit(
                                                         TestOptions.MINIMUM.getOptions(),
+                                                        ChangesFollower.Mode.LISTEN,
                                                         ChangesFollower.BATCH_SIZE);
 
     // A duration to use for testing error suppression

--- a/modules/cloudant/src/test/java/com/ibm/cloud/cloudant/features/TestOptions.java
+++ b/modules/cloudant/src/test/java/com/ibm/cloud/cloudant/features/TestOptions.java
@@ -19,6 +19,7 @@ import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 import com.ibm.cloud.cloudant.v1.model.PostChangesOptions;
+import com.ibm.cloud.cloudant.features.ChangesFollower.Mode;
 import com.ibm.cloud.cloudant.v1.model.GetDbUpdatesOptions.Feed;
 
 /**
@@ -129,14 +130,24 @@ enum TestOptions {
     }
 
     // Adds in the implementation expected changes
-    PostChangesOptions.Builder getExpectedOptionsBuilder() {
-        return this.getBuilder()
-            .feed(Feed.LONGPOLL)
-            .timeout(ChangesOptionsHelper.LONGPOLL_TIMEOUT);
+    PostChangesOptions.Builder getExpectedOptionsBuilder(Mode mode) {
+        PostChangesOptions.Builder b = this.getBuilder();
+        if (mode != null) {
+            switch (mode) {
+                case FINITE:
+                    b.feed(Feed.NORMAL);
+                    break;
+                case LISTEN:
+                    b.feed(Feed.LONGPOLL);
+                    b.timeout(ChangesOptionsHelper.LONGPOLL_TIMEOUT);
+                    break;
+            }   
+        }
+        return b;
     }
 
     // Adds in the implementation expected changes
-    PostChangesOptions getExpectedOptions() {
-        return this.getExpectedOptionsBuilder().build();
+    PostChangesOptions getExpectedOptions(Mode mode) {
+        return this.getExpectedOptionsBuilder(mode).build();
     }
 }


### PR DESCRIPTION
## PR summary

Use `normal` feed mode for changes follower one-off `FINITE` mode.

Fixes: s1116 / i445

**Note: An existing issue is [required](https://github.com/IBM/cloudant-java-sdk/blob/main/CONTRIBUTING.md#PRs) before opening a PR.**

## PR Checklist

Please make sure that your PR fulfills the following requirements:

- [x] The commit message follows the
[Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type  
<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [ ] Build/CI related changes
- [ ] Documentation content changes
- [x] Other (please describe) - performance improvement

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

Currently the changes follower uses `longpoll` feed type is for both `start` (`LISTEN`) and `startOneOff` (`FINITE`) cases.
If the number of changes is an exact multiple of the follower batch size this causes the one-off collection to unnecessarily wait for the longpoll period (57 s) when it reaches the end of the available changes. This is a rare occurrence, but one more common edge case is empty databases (i.e. the zero multiple).

## What is the new behavior?
<!-- Please describe the new behavior after your change. -->

Switch to use the `normal` feed type for `startOneOff` (`FINITE`) mode thereby optimizing the `startOneOff` cases to avoid waiting unnecessarily.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and
migration path for existing applications below. -->

## Other information

<!-- Please add any additional information that would help reviewers evaluate
your PR-->
